### PR TITLE
Node6.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "6"
+  - "5"
+  - "4"
 
 before_install:
   - sudo add-apt-repository --yes ppa:ubuntu-toolchain-r/test

--- a/src/vcd_decoder.cc
+++ b/src/vcd_decoder.cc
@@ -11,10 +11,11 @@
 #include "third-party/open-vcdiff/src/google/vcdecoder.h"
 
 VcdDecoder::VcdDecoder(
+    v8::Isolate* isolate,
     v8::Local<v8::Object> dictionary_handle,
     std::unique_ptr<open_vcdiff::VCDiffStreamingDecoder> decoder)
     : decoder_(std::move(decoder)),
-      dictionary_handle_(v8::Persistent<v8::Object>::New(dictionary_handle)),
+      dictionary_handle_(isolate, dictionary_handle),
       dictionary_buffer_(node::Buffer::Data(dictionary_handle)),
       dictionary_len_(node::Buffer::Length(dictionary_handle)) {
 }

--- a/src/vcd_decoder.h
+++ b/src/vcd_decoder.h
@@ -19,7 +19,8 @@ class VCDiffStreamingDecoder;
 
 class VcdDecoder : public VcdCtx::Coder {
  public:
-  VcdDecoder(v8::Local<v8::Object> dictionary_handle,
+  VcdDecoder(v8::Isolate* isolate,
+             v8::Local<v8::Object> dictionary_handle,
              std::unique_ptr<open_vcdiff::VCDiffStreamingDecoder> decoder);
   ~VcdDecoder();
 

--- a/src/vcd_encoder.cc
+++ b/src/vcd_encoder.cc
@@ -9,10 +9,11 @@
 #include "third-party/open-vcdiff/src/google/vcencoder.h"
 
 VcdEncoder::VcdEncoder(
+    v8::Isolate* isolate,
     v8::Local<v8::Object> hashed_dictionary,
     std::unique_ptr<open_vcdiff::VCDiffStreamingEncoder> encoder)
     : encoder_(std::move(encoder)),
-      hashed_dictionary_(v8::Persistent<v8::Object>::New(hashed_dictionary)) {
+      hashed_dictionary_(isolate, hashed_dictionary) {
 }
 
 VcdEncoder::~VcdEncoder() {

--- a/src/vcd_encoder.h
+++ b/src/vcd_encoder.h
@@ -19,7 +19,8 @@ class VCDiffStreamingEncoder;
 
 class VcdEncoder : public VcdCtx::Coder {
  public:
-  VcdEncoder(v8::Local<v8::Object> hashed_dictionary,
+  VcdEncoder(v8::Isolate* isolate,
+             v8::Local<v8::Object> hashed_dictionary,
              std::unique_ptr<open_vcdiff::VCDiffStreamingEncoder> encoder);
   ~VcdEncoder();
 

--- a/src/vcd_hashed_dictionary.h
+++ b/src/vcd_hashed_dictionary.h
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <node.h>
+#include <node_object_wrap.h>
 #include <v8.h>
 
 namespace open_vcdiff {
@@ -26,12 +27,12 @@ class VcdHashedDictionary : public node::ObjectWrap {
     return hashed_dictionary_.get();
   }
 
-  // v8 bindings
   static void Init(v8::Handle<v8::Object> exports);
-  static v8::Persistent<v8::Function> constructor;
-  static v8::Handle<v8::Value> New(const v8::Arguments& args);
 
  private:
+  static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static v8::Persistent<v8::Function> constructor;
+
   std::unique_ptr<open_vcdiff::HashedDictionary> hashed_dictionary_;
 
   VcdHashedDictionary(const VcdHashedDictionary& other) = delete;

--- a/src/vcdiff.cc
+++ b/src/vcdiff.cc
@@ -116,7 +116,6 @@ v8::Local<v8::Object> VcdCtx::Write(
 
   if (!async) {
     // sync version
-    v8::HandleScope handle_scope(isolate);
     Process(data, len, is_last);
     if (!CheckError(isolate))
       return v8::Local<v8::Object>();
@@ -187,6 +186,8 @@ bool VcdCtx::CheckError(v8::Isolate* isolate) {
 }
 
 void VcdCtx::SendError(v8::Isolate* isolate) {
+  v8::HandleScope handle_scope(isolate);
+
   v8::Local<v8::Value> args[2] = {
     v8::String::NewFromUtf8(isolate, GetErrorString(err_)),
     v8::Number::New(isolate, static_cast<int>(err_)),

--- a/src/vcdiff.cc
+++ b/src/vcdiff.cc
@@ -5,8 +5,6 @@
 // Released under the MIT license
 
 #include <memory>
-#include <vector>
-#include <iostream>
 
 #include <node.h>
 #include <node_buffer.h>
@@ -44,12 +42,12 @@ void VcdCtx::Close() {
 }
 
 // static
-v8::Handle<v8::Value> VcdCtx::New(const v8::Arguments& args) {
-  v8::HandleScope scope;
-
+void VcdCtx::New(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto mode = static_cast<Mode>(args[0]->Int32Value());
   assert((mode == Mode::ENCODE || mode == Mode::DECODE) &&
          "invalid operation mode (neither ENCODE nor DECODE");
+
+  v8::Isolate* isolate = args.GetIsolate();
 
   std::unique_ptr<Coder> coder;
   if (mode == Mode::ENCODE) {
@@ -59,7 +57,7 @@ v8::Handle<v8::Value> VcdCtx::New(const v8::Arguments& args) {
             hashed_dict->hashed_dictionary(),
             args[3]->Uint32Value(),
             args[2]->BooleanValue()));
-    coder.reset(new VcdEncoder(args[1]->ToObject(), std::move(encoder)));
+    coder.reset(new VcdEncoder(isolate, args[1]->ToObject(), std::move(encoder)));
   } else {
     assert(node::Buffer::HasInstance(args[1]) &&
            "Buffer required for decoder");
@@ -68,28 +66,27 @@ v8::Handle<v8::Value> VcdCtx::New(const v8::Arguments& args) {
     decoder->SetAllowVcdTarget(args[2]->BooleanValue());
     decoder->SetMaximumTargetFileSize(args[3]->Uint32Value());
     decoder->SetMaximumTargetWindowSize(args[4]->Uint32Value());
-    coder.reset(new VcdDecoder(args[1]->ToObject(), std::move(decoder)));
+    coder.reset(new VcdDecoder(isolate, args[1]->ToObject(), std::move(decoder)));
   }
 
   auto ctx = new VcdCtx(std::move(coder));
   ctx->Wrap(args.This());
-  return args.This();
 }
 
 // static
-v8::Handle<v8::Value> VcdCtx::WriteAsync(const v8::Arguments& args) {
-  return WriteInternal(args, true);
+void VcdCtx::WriteAsync(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  WriteInternal(args, true);
 }
 
 // static
-v8::Handle<v8::Value> VcdCtx::WriteSync(const v8::Arguments& args) {
-  return WriteInternal(args, false);
+void VcdCtx::WriteSync(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  WriteInternal(args, false);
 }
 
 // static
-v8::Handle<v8::Value> VcdCtx::WriteInternal(
-      const v8::Arguments& args, bool async) {
-  v8::HandleScope scope;
+void VcdCtx::WriteInternal(
+      const v8::FunctionCallbackInfo<v8::Value>& args, bool async) {
+  v8::Isolate* isolate = args.GetIsolate();
   VcdCtx* ctx = Unwrap<VcdCtx>(args.Holder());
   assert(node::Buffer::HasInstance(args[1]));
 
@@ -97,45 +94,49 @@ v8::Handle<v8::Value> VcdCtx::WriteInternal(
   auto in_buf = args[1]->ToObject();
   auto result = ctx->Write(in_buf, is_last, async);
 
-  if (result.IsEmpty())
-    return v8::Undefined();
-
-  return scope.Close(result);
+  if (result.IsEmpty()) {
+    args.GetReturnValue().Set(v8::Undefined(isolate));
+  } else {
+    args.GetReturnValue().Set(result);
+  }
 }
 
 v8::Local<v8::Object> VcdCtx::Write(
     v8::Local<v8::Object> buffer, bool is_last, bool async) {
+  v8::Isolate* isolate = buffer->GetIsolate();
+
   assert(coder_.get() && "attempt to write after finalization");
   assert(!write_in_progress_ && "write already in progress");
   assert(!pending_close_ && "close is pending");
 
   write_in_progress_ = true;
-  in_buffer_ = v8::Persistent<v8::Object>::New(buffer);
-  auto data = node::Buffer::Data(in_buffer_);
-  auto len = node::Buffer::Length(in_buffer_);
+  in_buffer_.Reset(isolate, buffer);
+  auto data = node::Buffer::Data(buffer);
+  auto len = node::Buffer::Length(buffer);
 
   if (!async) {
     // sync version
+    v8::HandleScope handle_scope(isolate);
     Process(data, len, is_last);
-    if (!CheckError())
+    if (!CheckError(isolate))
       return v8::Local<v8::Object>();
-    return FinishWrite();
+    return FinishWrite(isolate);
   } else {
-    work_req_.data = new WorkData { this, data, len, is_last };
+    work_req_.data = new WorkData { this, isolate, data, len, is_last };
     uv_queue_work(uv_default_loop(),
                   &work_req_,
                   ProcessShim,
                   AfterShim);
-    return v8::Local<v8::Object>::New(handle_);
+    return handle();
   }
 }
 
-v8::Local<v8::Array> VcdCtx::FinishWrite() {
+v8::Local<v8::Array> VcdCtx::FinishWrite(v8::Isolate* isolate) {
   write_in_progress_ = false;
-  in_buffer_.Clear();
-  auto result = v8::Array::New(2);
-  result->Set(0, GetOutputBuffer());
-  result->Set(1, v8::Boolean::New(state_ == State::DONE));
+  in_buffer_.Reset();
+  auto result = v8::Array::New(isolate, 2);
+  result->Set(0, GetOutputBuffer(isolate));
+  result->Set(1, v8::Boolean::New(isolate, state_ == State::DONE));
   output_buffer_.clear();
   return result;
 }
@@ -177,21 +178,20 @@ void VcdCtx::Process(const char* data, size_t len, bool is_last) {
 
 }
 
-bool VcdCtx::CheckError() {
+bool VcdCtx::CheckError(v8::Isolate* isolate) {
   if (!HasError())
     return true;
 
-  SendError();
+  SendError(isolate);
   return false;
 }
 
-void VcdCtx::SendError() {
-  v8::HandleScope scope;
+void VcdCtx::SendError(v8::Isolate* isolate) {
   v8::Local<v8::Value> args[2] = {
-    v8::String::New(GetErrorString(err_)),
-    v8::Number::New(static_cast<int>(err_)),
+    v8::String::NewFromUtf8(isolate, GetErrorString(err_)),
+    v8::Number::New(isolate, static_cast<int>(err_)),
   };
-  node::MakeCallback(v8::Local<v8::Object>::New(handle_), "onerror", 2, args);
+  node::MakeCallback(isolate, handle(), "onerror", 2, args);
 
   // no hope of rescue.
   write_in_progress_ = false;
@@ -203,18 +203,18 @@ bool VcdCtx::HasError() const {
   return err_ != Error::OK;
 }
 
-v8::Local<v8::Object> VcdCtx::GetOutputBuffer() {
+v8::Local<v8::Object> VcdCtx::GetOutputBuffer(v8::Isolate* isolate) {
   // TODO: avoid copying when return data.
-  auto buffer = node::Buffer::New(
+  auto buffer = node::Buffer::Copy(isolate,
       output_buffer_.data(), output_buffer_.size());
-  return v8::Local<v8::Object>::New(buffer->handle_);
+  return buffer.ToLocalChecked();
 }
 
 // static
-v8::Handle<v8::Value> VcdCtx::Close(const v8::Arguments& args) {
+void VcdCtx::Close(const v8::FunctionCallbackInfo<v8::Value>& args) {
   auto ctx = Unwrap<VcdCtx>(args.Holder());
   ctx->Close();
-  return v8::Undefined();
+  args.GetReturnValue().Set(v8::Undefined(args.GetIsolate()));
 }
 
 // static
@@ -226,22 +226,22 @@ void VcdCtx::ProcessShim(uv_work_t* work_req) {
 // static
 void VcdCtx::AfterShim(uv_work_t* work_req, int status) {
   assert(status == 0);
+
   std::unique_ptr<WorkData> data(
       static_cast<WorkData*>(work_req->data));
+  v8::Isolate* isolate = data->isolate;
+  v8::HandleScope handle_scope(isolate);
   VcdCtx* ctx = data->ctx;
 
-  v8::HandleScope scope;
-
-  if (!ctx->CheckError())
+  if (!ctx->CheckError(isolate))
     return;
 
-  auto result = ctx->FinishWrite();
+  auto result = ctx->FinishWrite(isolate);
   v8::Local<v8::Value> args[2] = {
     result->Get(0),
     result->Get(1),
   };
-  node::MakeCallback(
-      v8::Local<v8::Object>::New(ctx->handle_), "callback", 2, args);
+  node::MakeCallback(isolate, ctx->handle(), "callback", 2, args);
 
   if (ctx->pending_close_)
     ctx->Close();
@@ -263,11 +263,12 @@ const char* VcdCtx::GetErrorString(VcdCtx::Error err) {
 
 // static
 void VcdCtx::Init(v8::Handle<v8::Object> exports) {
-  v8::HandleScope scope;
+  v8::Isolate* isolate = exports->GetIsolate();
+  v8::Local<v8::String> className = v8::String::NewFromUtf8(isolate, "Vcdiff", v8::String::kInternalizedString);
 
   // Prepare constructor template
-  v8::Local<v8::FunctionTemplate> tpl = v8::FunctionTemplate::New(New);
-  tpl->SetClassName(v8::String::NewSymbol("Vcdiff"));
+  v8::Local<v8::FunctionTemplate> tpl = v8::FunctionTemplate::New(isolate, New);
+  tpl->SetClassName(className);
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
   // Prototype
@@ -275,14 +276,13 @@ void VcdCtx::Init(v8::Handle<v8::Object> exports) {
   NODE_SET_PROTOTYPE_METHOD(tpl, "writeSync", WriteSync);
   NODE_SET_PROTOTYPE_METHOD(tpl, "close", Close);
 
-  constructor = v8::Persistent<v8::Function>::New(tpl->GetFunction());
-  exports->Set(v8::String::NewSymbol("Vcdiff"), constructor);
+  exports->Set(className, tpl->GetFunction());
 
 #define NODE_SET_CONSTANT_FROM_ENUM(target, name, value) \
-  (target)->Set(v8::String::NewSymbol(#name), \
-                v8::Number::New(static_cast<double>((value))), \
-                static_cast<v8::PropertyAttribute>( \
-                    v8::ReadOnly | v8::DontDelete)); \
+  (target)->ForceSet(v8::String::NewFromUtf8(isolate, #name, v8::String::kInternalizedString), \
+                     v8::Number::New(isolate, static_cast<double>((value))), \
+                     static_cast<v8::PropertyAttribute>( \
+                         v8::ReadOnly | v8::DontDelete)); \
 
   NODE_SET_CONSTANT_FROM_ENUM(exports, ENCODE, Mode::ENCODE);
   NODE_SET_CONSTANT_FROM_ENUM(exports, DECODE, Mode::DECODE);

--- a/test/vcdiff.coffee
+++ b/test/vcdiff.coffee
@@ -205,11 +205,15 @@ describe 'vcdiff', ->
         allowVcdTarget: true
       encoder.should.be.instanceof vcd.VcdiffDecoder
 
-    it 'should return error if input invalid', (done) ->
+    it 'should return error if input is invalid (sync)', ->
       dict = new Buffer 'this is a test dictionary not very long'
       testData = 'this is a test dictionary not very long a test dictionary not'
       (-> vcd.vcdiffDecodeSync testData, dictionary: dict)
       .should.throw /Vcdiff decode error/
+
+    it 'should return error if input invalid (async)', (done) ->
+      dict = new Buffer 'this is a test dictionary not very long'
+      testData = 'this is a test dictionary not very long a test dictionary not'
 
       vcd.vcdiffDecode testData, dictionary: dict, (err, data) ->
         err.message.should.contain.string 'Vcdiff decode error'


### PR DESCRIPTION
I came. I saw. I compiled.

I'm merely intermediate when it comes to Node extensions, so I may have erred. I think these changes are correct, though.

Themes:
- `v8::Isolate` galore. (I avoided the evil `v8::Isolate::GetCurrent()`.)
- `node_object_wrap.h` has different usage now

I suspect this will compile and run on Node v4 (stable), too; but I haven't tested.
